### PR TITLE
update: making the workflow deploy to different environment based on the current ref

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   Infra_provisioning:
     runs-on: ubuntu-latest
-    environment: dev  
+    environment: ${{ github.ref }}  
     defaults:
       run:
         shell: bash

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: echo the current branch
         run:  |
-          echo "Current branch is: ${github.head_ref}"
+          echo "Current branch is: ${{ github.head_ref }}"
     
       - name: Configure AWS Credentials for Development Environment
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   Infra_provisioning:
     runs-on: ubuntu-latest
-    environment: dev 
+    environment: ${{ github.head_ref }}
     defaults:
       run:
         shell: bash
@@ -30,7 +30,7 @@ jobs:
 
       - name: echo the current branch
         run:  |
-          echo "Current branch is:  ${GITHUB_HEAD_REF}"
+          echo "Current branch is: ${github.head_ref}"
     
       - name: Configure AWS Credentials for Development Environment
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -29,7 +29,8 @@ jobs:
         uses: actions/checkout@v4
 
       - name: echo the current branch
-        run:  "Current branch is:  ${GITHUB_REF#refs/heads/}"
+        run:  |
+          echo "Current branch is:  ${GITHUB_REF#refs/heads/}"
     
       - name: Configure AWS Credentials for Development Environment
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,7 +17,8 @@ permissions:
 jobs:
   Infra_provisioning:
     runs-on: ubuntu-latest
-    environment: ${{ github.head_ref }}
+    # environment: ${{ github.head_ref }}
+    environment: dev
     defaults:
       run:
         shell: bash

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   Infra_provisioning:
     runs-on: ubuntu-latest
-    environment: ${{ github.ref }}  
+    environment: dev 
     defaults:
       run:
         shell: bash
@@ -27,6 +27,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+
+      - name: echo the current branch
+        run:  "Current branch is:  ${GITHUB_REF#refs/heads/}"
     
       - name: Configure AWS Credentials for Development Environment
         uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -30,7 +30,7 @@ jobs:
 
       - name: echo the current branch
         run:  |
-          echo "Current branch is:  ${GITHUB_REF#refs/heads/}"
+          echo "Current branch is:  ${GITHUB_HEAD_REF}"
     
       - name: Configure AWS Credentials for Development Environment
         uses: aws-actions/configure-aws-credentials@v4

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
 # High Availability Microservice Deployment
 
 **Will be expanding on this document**
+
+[![Terraform Infrastructure Provisioning](https://github.com/oriafo/ha_microservice_deployment_v1.0/actions/workflows/terraform.yaml/badge.svg?branch=dev&event=pull_request)](https://github.com/oriafo/ha_microservice_deployment_v1.0/actions/workflows/terraform.yaml)


### PR DESCRIPTION
Making the workflow deploy to different environment based on the current ref. this id important because each pr created in different branch should be able to pick different credentials tied to different environment